### PR TITLE
Initial commit of Send/Receive support.

### DIFF
--- a/AzureNetQ.Tests.SendReceive/App.config
+++ b/AzureNetQ.Tests.SendReceive/App.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
+  <appSettings>
+    <add key="Microsoft.ServiceBus.ConnectionString"
+         value="Endpoint=sb://servicebus/ServiceBusDefaultNamespace;StsEndpoint=https://servicebus:10355/ServiceBusDefaultNamespace;RuntimePort=10354;ManagementPort=10355" />
+  </appSettings>
+</configuration>

--- a/AzureNetQ.Tests.SendReceive/AzureNetQ.Tests.SendReceive.csproj
+++ b/AzureNetQ.Tests.SendReceive/AzureNetQ.Tests.SendReceive.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>AzureNetQ.Tests.SendReceive</RootNamespace>
+    <AssemblyName>AzureNetQ.Tests.SendReceive</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AzureNetQ.Tests.Messages\AzureNetQ.Tests.Messages.csproj">
+      <Project>{fd277901-413f-4064-8a38-57a3609872cb}</Project>
+      <Name>AzureNetQ.Tests.Messages</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\AzureNetQ\AzureNetQ.csproj">
+      <Project>{b8def709-5168-48f1-b8d3-ad44e4a4a22b}</Project>
+      <Name>AzureNetQ</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/AzureNetQ.Tests.SendReceive/Program.cs
+++ b/AzureNetQ.Tests.SendReceive/Program.cs
@@ -1,0 +1,69 @@
+﻿using AzureNetQ.Tests.Messages;
+using System;
+
+namespace AzureNetQ.Tests.SendReceive
+{
+    class Program
+    {
+        private static string SendReceiveQueue = "azurenetq.tests.sendreceive";
+        private static string AuditQueue = "azurenetq.tests.sendreceive.audit";
+        
+        static void Main(string[] args)
+        {
+            new Program().Run();
+        }
+
+        private IBus bus;
+
+        private void Run()
+        {
+            bus = AzureBusFactory.CreateBus();
+
+            bus.Receive(SendReceiveQueue, handlers =>
+            {
+                handlers
+                    .Add<TestSendMessage>(msg => Console.WriteLine("Handler 1 Received message: {0}", msg.Text))
+                    .Add<TestSendMessage2>(msg => Console.WriteLine("Handler 2 Received message: {0}", msg.Text));
+            });
+
+            bus.Receive<TestSendMessageBase>(AuditQueue, msg => Console.WriteLine("Auditor Received message: {0}", msg.Text));
+
+            Console.WriteLine("Type a message or 'q' to quit.");
+
+            string text = null;
+            while ((text = Console.ReadLine()) != "q")
+            {
+                foreach (var queue in new[] { SendReceiveQueue, AuditQueue })
+                {
+                    bus.Send(queue, new TestSendMessage
+                    {
+                        Text = text
+                    });
+
+                    bus.Send(queue, new TestSendMessage2
+                    {
+                        Text = text
+                    });
+                }
+            }
+
+            bus.Dispose();
+        }
+    }
+
+    [Serializable]
+    public class TestSendMessageBase
+    {
+        public string Text { get; set; }
+    }
+
+    [Serializable]
+    public class TestSendMessage : TestSendMessageBase
+    {
+    }
+
+    [Serializable]
+    public class TestSendMessage2 : TestSendMessageBase
+    {
+    }
+}

--- a/AzureNetQ.Tests.SendReceive/Properties/AssemblyInfo.cs
+++ b/AzureNetQ.Tests.SendReceive/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("AzureNetQ.Tests.SendReceive")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AzureNetQ.Tests.SendReceive")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5fb49418-75c0-4d24-9689-5ce23c2f7e88")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/AzureNetQ.sln
+++ b/AzureNetQ.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+VisualStudioVersion = 12.0.30501.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureNetQ", "AzureNetQ\AzureNetQ.csproj", "{B8DEF709-5168-48F1-B8D3-AD44E4A4A22B}"
 EndProject
@@ -16,6 +16,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureNetQ.Trace", "AzureNetQ.Trace\AzureNetQ.Trace.csproj", "{11DF08A9-3D14-44CC-A65E-5933121D3D63}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureNetQ.Tests.Messages", "AzureNetQ.Tests.Messages\AzureNetQ.Tests.Messages.csproj", "{FD277901-413F-4064-8A38-57A3609872CB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AzureNetQ.Tests.SendReceive", "AzureNetQ.Tests.SendReceive\AzureNetQ.Tests.SendReceive.csproj", "{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -135,6 +137,21 @@ Global
 		{FD277901-413F-4064-8A38-57A3609872CB}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{FD277901-413F-4064-8A38-57A3609872CB}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{FD277901-413F-4064-8A38-57A3609872CB}.Release|x86.ActiveCfg = Release|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.DebugCloud|Any CPU.ActiveCfg = Debug|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.DebugCloud|Any CPU.Build.0 = Debug|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.DebugCloud|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.DebugCloud|Mixed Platforms.Build.0 = Debug|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.DebugCloud|x86.ActiveCfg = Debug|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{4818FCD2-1E75-4CEA-8B00-E5259E217BB8}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AzureNetQ/AzureNetQ.csproj
+++ b/AzureNetQ/AzureNetQ.csproj
@@ -75,7 +75,11 @@
     <Compile Include="AzureAdvancedBus.cs" />
     <Compile Include="AzureBusFactory.cs" />
     <Compile Include="AzureNetQSettings.cs" />
+    <Compile Include="BrokeredMessageExtensions.cs" />
+    <Compile Include="Consumer\HandlerCollection.cs" />
+    <Compile Include="Consumer\HandlerCollectionFactory.cs" />
     <Compile Include="Consumer\IConsumerConfiguration.cs" />
+    <Compile Include="Consumer\IHandlerCollectionFactory.cs" />
     <Compile Include="Consumer\IHandlerRegistration.cs" />
     <Compile Include="Consumer\IReceiveRegistration.cs" />
     <Compile Include="Consumer\ConsumerDispatcher.cs" />

--- a/AzureNetQ/AzureNetQSettings.cs
+++ b/AzureNetQ/AzureNetQSettings.cs
@@ -4,6 +4,7 @@
 
     using AzureNetQ.Loggers;
     using AzureNetQ.Producer;
+    using AzureNetQ.Consumer;
 
     public class AzureNetQSettings
     {
@@ -12,7 +13,6 @@
         public AzureNetQSettings()
         {
             this.Logger = () => new NullLogger();
-            this.SendAndReceive = () => new SendReceive();
             this.Conventions = () => new Conventions(new TypeNameSerializer());
             this.ConnectionConfiguration = () => connectionConfiguration = connectionConfiguration ?? new ConnectionConfiguration();
             this.Serializer = () => new JsonSerializer(new TypeNameSerializer());
@@ -27,6 +27,15 @@
                     this.AzureAdvancedBus.Value,
                     this.ConnectionConfiguration(),
                     this.Serializer());
+
+            this.SendAndReceive = 
+                () => 
+                    new SendReceive(
+                        this.AzureAdvancedBus.Value, 
+                        this.ConnectionConfiguration(),
+                        new HandlerCollectionFactory(this.Logger()),
+                        new TypeNameSerializer(),
+                        this.Serializer());
         }
 
         public Lazy<IAzureAdvancedBus> AzureAdvancedBus { get; set; }

--- a/AzureNetQ/BrokeredMessageExtensions.cs
+++ b/AzureNetQ/BrokeredMessageExtensions.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.ServiceBus.Messaging;
+
+namespace AzureNetQ
+{
+    internal static class BrokeredMessageExtensions
+    {
+        private static string MessageTypePropertyKey = "Type";
+        
+        public static void SetMessageType(this BrokeredMessage message, string typeName)
+        {
+            Preconditions.CheckNotNull(message, "message");
+            Preconditions.CheckNotNull(typeName, "typeName");
+
+            message.Properties[MessageTypePropertyKey] = typeName;
+        }
+
+        public static string GetMessageType(this BrokeredMessage message)
+        {
+            Preconditions.CheckNotNull(message, "message");
+
+            object prop;
+            if (message.Properties.TryGetValue(MessageTypePropertyKey, out prop))
+            {
+                return prop.ToString();
+            }
+
+            return null;
+        }
+    }
+}

--- a/AzureNetQ/Consumer/HandlerCollection.cs
+++ b/AzureNetQ/Consumer/HandlerCollection.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AzureNetQ.Consumer
+{
+    public class HandlerCollection : IHandlerCollection
+    {
+        private readonly IDictionary<Type, object> handlers = new Dictionary<Type, object>();
+
+        private readonly IAzureNetQLogger logger;
+
+        public HandlerCollection(IAzureNetQLogger logger)
+        {
+            Preconditions.CheckNotNull(logger, "logger");
+
+            this.logger = logger;
+            ThrowOnNoMatchingHandler = true;
+        }
+
+        public IHandlerRegistration Add<T>(Func<IMessage<T>, MessageReceivedInfo, Task> handler) where T : class
+        {
+            Preconditions.CheckNotNull(handler, "handler");
+
+            if (handlers.ContainsKey(typeof(T)))
+            {
+                throw new AzureNetQException("There is already a handler for message type '{0}'", typeof(T).Name);
+            }
+
+            handlers.Add(typeof(T), handler);
+            return this;
+        }
+
+        public IHandlerRegistration Add<T>(Action<IMessage<T>, MessageReceivedInfo> handler) where T : class
+        {
+            Preconditions.CheckNotNull(handler, "handler");
+
+            Add<T>((message, info) => TaskHelpers.ExecuteSynchronously(() => handler(message, info)));
+            return this;
+        }
+
+        // NOTE: refactoring tools might suggest this method is never invoked. Ignore them it
+        // _is_ invoked by the GetHandler(Type messsageType) method below by reflection.
+        public Func<IMessage<T>, MessageReceivedInfo, Task> GetHandler<T>() where T : class
+        {
+            // return (Func<IMessage<T>, MessageReceivedInfo, Task>)GetHandler(typeof(T));
+            var messageType = typeof(T);
+
+            if (handlers.ContainsKey(messageType))
+            {
+                return (Func<IMessage<T>, MessageReceivedInfo, Task>)handlers[messageType];
+            }
+
+            // no exact handler match found, so let's see if we can find a handler that
+            // handles a supertype of the consumed message.
+            foreach (var handlerType in handlers.Keys.Where(type => type.IsAssignableFrom(messageType)))
+            {
+                return (Func<IMessage<T>, MessageReceivedInfo, Task>)handlers[handlerType];
+            }
+
+            if (ThrowOnNoMatchingHandler)
+            {
+                logger.ErrorWrite("No handler found for message type {0}", messageType.Name);
+                throw new AzureNetQException("No handler found for message type {0}", messageType.Name);
+            }
+
+            return (message, info) => Task.Factory.StartNew(() => { });
+        }
+
+        public dynamic GetHandler(Type messageType)
+        {
+            Preconditions.CheckNotNull(messageType, "messageType");
+
+            var getHandlerGenericMethod = GetType().GetMethod("GetHandler", new Type[0]).MakeGenericMethod(messageType);
+
+            return getHandlerGenericMethod.Invoke(this, new object[0]);
+        }
+
+        public bool ThrowOnNoMatchingHandler { get; set; }
+    }
+}

--- a/AzureNetQ/Consumer/HandlerCollectionFactory.cs
+++ b/AzureNetQ/Consumer/HandlerCollectionFactory.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AzureNetQ.Consumer
+{
+    public class HandlerCollectionFactory : IHandlerCollectionFactory
+    {
+        private readonly IAzureNetQLogger logger;
+
+        public HandlerCollectionFactory(IAzureNetQLogger logger)
+        {
+            this.logger = logger;
+        }
+
+        public IHandlerCollection CreateHandlerCollection()
+        {
+            return new HandlerCollection(logger);
+        }
+    }
+}

--- a/AzureNetQ/Consumer/IHandlerCollectionFactory.cs
+++ b/AzureNetQ/Consumer/IHandlerCollectionFactory.cs
@@ -1,0 +1,8 @@
+﻿
+namespace AzureNetQ.Consumer
+{
+    public interface IHandlerCollectionFactory
+    {
+        IHandlerCollection CreateHandlerCollection();
+    }
+}

--- a/AzureNetQ/Producer/SendReceive.cs
+++ b/AzureNetQ/Producer/SendReceive.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using AzureNetQ.Consumer;
+using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
-using AzureNetQ.Consumer;
 
 namespace AzureNetQ.Producer
 {
@@ -9,10 +9,32 @@ namespace AzureNetQ.Producer
 
     public class SendReceive : ISendReceive
     {
+        private readonly IAzureAdvancedBus advancedBus;
+        private readonly IConnectionConfiguration connectionConfiguration;
+        private readonly IHandlerCollectionFactory handlerCollectionFactory;
+        private readonly ITypeNameSerializer typeNameSerializer;
+        private readonly ISerializer serializer;
+        
         private readonly ConcurrentDictionary<string, QueueClient> declaredQueues = new ConcurrentDictionary<string, QueueClient>(); 
 
-        public SendReceive()
+        public SendReceive(
+            IAzureAdvancedBus advancedBus, 
+            IConnectionConfiguration connectionConfiguration, 
+            IHandlerCollectionFactory handlerCollectionFactory,
+            ITypeNameSerializer typeNameSerializer,
+            ISerializer serializer)
         {
+            Preconditions.CheckNotNull(advancedBus, "advancedBus");
+            Preconditions.CheckNotNull(connectionConfiguration, "connectionConfiguration");
+            Preconditions.CheckNotNull(handlerCollectionFactory, "handlerCollectionFactory");
+            Preconditions.CheckNotNull(typeNameSerializer, "typeNameSerializer");
+            Preconditions.CheckNotNull(serializer, "serializer");
+
+            this.advancedBus = advancedBus;
+            this.connectionConfiguration = connectionConfiguration;
+            this.handlerCollectionFactory = handlerCollectionFactory;
+            this.typeNameSerializer = typeNameSerializer;
+            this.serializer = serializer;
         }
 
         public void Send<T>(string queue, T message)
@@ -21,7 +43,13 @@ namespace AzureNetQ.Producer
             Preconditions.CheckNotNull(queue, "queue");
             Preconditions.CheckNotNull(message, "message");
 
-            throw new NotImplementedException();
+            var declaredQueue = DeclareQueue(queue);
+
+            var content = serializer.MessageToString(message);
+            var queueMessage = new BrokeredMessage(content);
+            queueMessage.SetMessageType(typeNameSerializer.Serialize(typeof(T)));
+
+            declaredQueue.Send(queueMessage);
         }
 
         public IDisposable Receive<T>(string queue, Action<T> onMessage)
@@ -39,12 +67,84 @@ namespace AzureNetQ.Producer
             Preconditions.CheckNotNull(queue, "queue");
             Preconditions.CheckNotNull(onMessage, "onMessage");
 
-            throw new NotImplementedException();
+            var declaredQueue = DeclareQueue(queue);
+            return Consume(declaredQueue, handlers => handlers.Add<T>((wrapped, info) => onMessage(wrapped.Body)));
         }
 
         public IDisposable Receive(string queue, Action<IReceiveRegistration> addHandlers)
         {
-            throw new NotImplementedException();
+            Preconditions.CheckNotNull(queue, "queue");
+            Preconditions.CheckNotNull(addHandlers, "addHandlers");
+
+            var declaredQueue = DeclareQueue(queue);
+            return Consume(declaredQueue, x => addHandlers(new HandlerAdder(x)));
+        }
+
+        private IDisposable Consume(QueueClient declaredQueue, Action<IHandlerRegistration> addHandlers)
+        {
+            var handlerCollection = handlerCollectionFactory.CreateHandlerCollection();
+            addHandlers(handlerCollection);
+
+            declaredQueue.OnMessageAsync(queueMessage =>
+            {
+                var messageBody = queueMessage.GetBody<string>();
+                var messageType = queueMessage.GetMessageType();
+
+                var message = this.serializer.StringToMessage(messageType, messageBody);
+                var handler = handlerCollection.GetHandler(message.GetType());
+                var wrappedMessageType = typeof(WrappedMessage<>).MakeGenericType(message.GetType());
+                dynamic wrappedMessage = Activator.CreateInstance(wrappedMessageType, message, new MessageProperties());
+
+                return handler(wrappedMessage, new MessageReceivedInfo()); // HACK - not using MessageReceievedInfo
+            });
+
+            return null;
+        }
+
+        private QueueClient DeclareQueue(string queueName)
+        {
+            QueueClient queue = null;
+            declaredQueues.AddOrUpdate(
+                queueName,
+                key => queue = advancedBus.QueueDeclare(queueName),
+                (key, value) => queue = value
+            );
+
+            return queue;
+        }
+
+        private class HandlerAdder : IReceiveRegistration
+        {
+            private readonly IHandlerRegistration handlerRegistration;
+
+            public HandlerAdder(IHandlerRegistration handlerRegistration)
+            {
+                this.handlerRegistration = handlerRegistration;
+            }
+
+            public IReceiveRegistration Add<T>(Func<T, Task> onMessage) where T : class
+            {
+                handlerRegistration.Add<T>((message, info) => onMessage(message.Body));
+                return this;
+            }
+
+            public IReceiveRegistration Add<T>(Action<T> onMessage) where T : class
+            {
+                handlerRegistration.Add<T>((message, info) => onMessage(message.Body));
+                return this;
+            }
+        }
+
+        private class WrappedMessage<T> : IMessage<T>
+        {
+            public T Body { get; private set; }
+            public MessageProperties Properties { get; private set; }
+            
+            public WrappedMessage(T body, MessageProperties properties)
+            {
+                Body = body;
+                Properties = properties;
+            }
         }
     }
 }


### PR DESCRIPTION
Added support for Send/Receive.

I had to jump through a few hoops to handle handler registration, mainly due to how EasyNetQ wraps messages in `IMessage<T>`. Whilst AzureNetQ has this interface it does not look like it is being used. For now I've just created a `WrappedMessage<T>` implementation but it would be nicer if we just passed a `BrokeredMessage` instance.

Also had to do a bit of a [hack](https://github.com/benfoster/AzureNetQ/compare/features/sendreceive?expand=1#diff-2b52ebf412cd544ed670c02b6cfd59d6R98) due to the handler collection's dependency on `MessageReceievedInfo` which again does not appear to be used anywhere.

Oh, and no tests :/
